### PR TITLE
Switch production mailer to SMTP

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -44,7 +44,16 @@ Vellum::Application.configure do
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false
 
-  config.action_mailer.delivery_method = :sendmail
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address:              ENV['SMTP_HOST']     || 'smtp.gmail.com',
+    port:                 ENV['SMTP_PORT']&.to_i || 587,
+    domain:               ENV['SMTP_DOMAIN']   || 'gmail.com',
+    user_name:            ENV['SMTP_USERNAME'],
+    password:             ENV['SMTP_PASSWORD'],
+    authentication:       :plain,
+    enable_starttls_auto: true
+  }
 
   # Enable threaded mode
   # config.threadsafe!


### PR DESCRIPTION
### Purpose

Sendmail isn't set up on the production server, so the migration notification emails were never going to work. This swaps the delivery method to SMTP and reads all credentials from environment variables.

### Changes

Set these env vars to configure (defaults to Gmail on port 587 with STARTTLS):

- `SMTP_USERNAME`
- `SMTP_PASSWORD` — use a Gmail App Password, not your regular password
- `SMTP_HOST` *(default: smtp.gmail.com)*
- `SMTP_PORT` *(default: 587)*
- `SMTP_DOMAIN` *(default: gmail.com)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)