### PR TITLE
Fix remaining filter_map incompatibility with Ruby 2.6

### DIFF
--- a/lib/tasks/google_drive_export.rake
+++ b/lib/tasks/google_drive_export.rake
@@ -82,9 +82,9 @@ namespace :google_drive do
     any_failures = false
 
     Project.where.not(google_drive_folder_url: nil).order(:name).each do |project|
-      failed_emails = (project.google_drive_warnings || []).filter_map do |warning|
+      failed_emails = (project.google_drive_warnings || []).map do |warning|
         warning.match(/\ACould not share with (.+?):/)[1] rescue nil
-      end
+      end.compact
       next if failed_emails.empty?
 
       unless any_failures

--- a/lib/tasks/migration_email.rake
+++ b/lib/tasks/migration_email.rake
@@ -13,9 +13,9 @@ namespace :vellum do
     abort "Set LOG_FILE to the path of the notify_migration output log." unless log_path
     abort "File not found: #{log_path}" unless File.exist?(log_path)
 
-    emails = File.readlines(log_path, chomp: true).filter_map do |line|
+    emails = File.readlines(log_path, chomp: true).map do |line|
       line.match(/\ASent to (.+)\z/)&.[](1)&.strip
-    end
+    end.compact
 
     abort "No 'Sent to ...' lines found in #{log_path}." if emails.empty?
 


### PR DESCRIPTION
## Summary
- `google_drive_export.rake`'s `sharing_failures` task still used `filter_map`, which doesn't exist on Ruby 2.6 (production's runtime). Same class of bug as the earlier fix in `migration_email.rake` (#131), just missed in that pass.
- Confirmed directly on the production machine that this line is still unpatched there — needed before running `sharing_failures` today.

## Test plan
- [ ] CI passes
- [ ] Merge and deploy
- [ ] Run `google_drive:sharing_failures` in production after deploy to confirm it no longer raises