### PR TITLE
Fix double-serialization crash in google_drive:export

### DIFF
--- a/lib/tasks/google_drive_export.rake
+++ b/lib/tasks/google_drive_export.rake
@@ -63,7 +63,7 @@ namespace :google_drive do
       project.update_columns(
         google_drive_folder_url: result[:folder_url],
         google_drive_exported_at: Time.now,
-        google_drive_warnings: result[:warnings].to_yaml
+        google_drive_warnings: result[:warnings]
       )
 
       puts "  Folder URL: #{result[:folder_url]}"


### PR DESCRIPTION
## Summary
- `Project#google_drive_warnings` is `serialize :google_drive_warnings, Array` — the rake task was calling `.to_yaml` on the warnings array before assigning it, so ActiveRecord's own serializer then tried to dump a String instead of an Array and raised `ActiveRecord::SerializationTypeMismatch`.
- This crashed the `google_drive:export` task on the very first project, every single time, regardless of whether that project actually had any sharing warnings — confirmed live in production today (0 of 179 projects had ever exported successfully).
- Verified the fix locally via both `save!` and `update_columns` (the exact method the task uses) — warnings now round-trip correctly as an Array.

## Test plan
- [x] Verified locally that `update_columns(google_drive_warnings: [...])` round-trips correctly
- [ ] CI passes
- [ ] Merge and deploy
- [ ] Re-run `google_drive:export` in production