### PR TITLE
Fix DB connection pool leak in google_drive:export

### DIFF
--- a/app/services/google_drive_exporter.rb
+++ b/app/services/google_drive_exporter.rb
@@ -100,6 +100,8 @@ class GoogleDriveExporter
           break unless item
           block.call(item)
         end
+      ensure
+        ActiveRecord::Base.clear_active_connections!
       end
     end.each(&:join)
   end


### PR DESCRIPTION
## Summary
- `GoogleDriveExporter#parallel_each` spawns up to 8 raw `Thread.new` workers per call (once for docs, once for doc-relationship re-links), and none of them released their ActiveRecord connection back to the pool when done.
- This Rails app is on 4.2, which does not auto-reclaim connections from threads that die without an explicit checkin (that reaping behavior came later). So every `parallel_each` call permanently leaked up to 8 connections.
- With `pool: 16` in `database.yml`, this exhausted the pool after about 2 projects' worth of work, then every subsequent checkout attempt hung 5s and raised `ActiveRecord::ConnectionTimeoutError`, aborting the whole `google_drive:export` task.
- Confirmed live in production today — running the (now credential- and serialization-fixed) export got only partway through the very first project before cascading connection timeouts killed the task.

## Test plan
- [x] Verified locally: without the fix, in-use connections climb across repeated `parallel_each` calls (1 -> 9 -> 11 of 16) until exhausted; with the fix, in-use stays flat at 1
- [ ] CI passes
- [ ] Merge and deploy
- [ ] Re-run `google_drive:export` in production