### PR TITLE
Fix production DB connection pool size (was silently defaulting to 5)

### DIFF
--- a/config/database.yml.docker
+++ b/config/database.yml.docker
@@ -47,6 +47,7 @@ params = CGI.parse(uri.query || "")
   <%= attribute "password", password, true %>
   <%= attribute "host",     host %>
   <%= attribute "port",     port %>
+  pool: <%= ENV["DB_POOL"] || 16 %>
 
 <% params.each do |key, value| %>
   <%= key %>: <%= value.first %>


### PR DESCRIPTION
## Summary
- `config/database.yml.docker` is swapped in for `config/database.yml` in the Docker image (`RUN mv config/database.yml.docker config/database.yml` in the Dockerfile) and is what actually runs in production.
- It builds the config purely from parsing `DATABASE_URL`'s components and never set a `pool` key, so ActiveRecord silently fell back to its hardcoded default of 5 connections -- confirmed directly in production (`ActiveRecord::Base.connection_pool.size == 5`).
- This is why `google_drive:export`'s `parallel_each` (up to 8 threads + the main thread, i.e. up to 9 concurrent connections needed) kept exhausting the pool and raising `ActiveRecord::ConnectionTimeoutError` on the very first project it touched, even after fixing the connection-release bug in #134.
- Added `pool: <%= ENV["DB_POOL"] || 16 %>` to match the intent already expressed in the non-Docker `database.yml`.

(Side note, not addressed here: this file's `attribute` helper has an unrelated pre-existing bug -- `"\#{name}: \#{value_string}"` escapes the interpolation, so every adapter/host/database/etc. line it emits renders as a literal `#{...}` string, which YAML then treats as a comment. Production has only ever been connecting because Rails auto-resolves the connection straight from `DATABASE_URL` regardless of what's in this file. Harmless today and out of scope for migration day, flagging for later.)

## Test plan
- [x] Verified locally that the added `pool:` line survives YAML parsing correctly
- [ ] CI passes
- [ ] Merge and deploy
- [ ] Confirm `connection_pool.size` is 16 in production
- [ ] Re-run `google_drive:export`