### PR TITLE
Make google_drive:export resilient to transient failures

### DIFF
--- a/app/services/google_drive_exporter.rb
+++ b/app/services/google_drive_exporter.rb
@@ -248,12 +248,21 @@ class GoogleDriveExporter
     ].join("\r\n")
   end
 
-  def execute(uri, req)
+  TRANSIENT_ERRORS = [
+    Errno::ECONNRESET, Errno::ECONNREFUSED, Errno::ETIMEDOUT, Errno::EPIPE,
+    EOFError, OpenSSL::SSL::SSLError, Net::OpenTimeout, Net::ReadTimeout
+  ].freeze
+
+  def execute(uri, req, attempt: 1)
     response = Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |http| http.request(req) }
     unless response.is_a?(Net::HTTPSuccess)
       raise "Drive API error #{response.code}: #{response.body}"
     end
     JSON.parse(response.body)
+  rescue *TRANSIENT_ERRORS
+    raise if attempt >= 3
+    sleep(attempt)
+    execute(uri, req, attempt: attempt + 1)
   end
 
   # ── Service account JWT auth ───────────────────────────────────────────────

--- a/lib/tasks/google_drive_export.rake
+++ b/lib/tasks/google_drive_export.rake
@@ -56,9 +56,17 @@ namespace :google_drive do
 
     puts "Exporting #{projects.size} project(s)...\n\n"
 
+    failed = []
+
     projects.each do |project|
       puts "=== #{project.name} ==="
-      result = exporter.export_project(project, parent_folder_id: parent_folder_id)
+      begin
+        result = exporter.export_project(project, parent_folder_id: parent_folder_id)
+      rescue => e
+        puts "  FAILED: #{e.class}: #{e.message}"
+        failed << project
+        next
+      end
 
       project.update_columns(
         google_drive_folder_url: result[:folder_url],
@@ -72,6 +80,11 @@ namespace :google_drive do
         result[:warnings].each { |w| puts "    - #{w}" }
       end
       puts
+    end
+
+    if failed.any?
+      puts "#{failed.size} project(s) failed and were skipped (re-run this task to retry them):"
+      failed.each { |p| puts "  #{p.name} (id: #{p.id})" }
     end
 
     puts "Done."


### PR DESCRIPTION
## Summary
Today's export run has hit five distinct crashes in production, each killing the entire remaining batch: service-account storage quota, a warnings-serialization bug, a DB connection pool leak, a silently-defaulted pool size of 5, and now a plain `Errno::ECONNRESET` mid-upload. The first four were genuine bugs (fixed in #132-#135); this one is different -- a transient network blip is *expected* over hundreds of HTTP calls to Google's API, not exceptional, and the task had no resilience to it at all.

- `GoogleDriveExporter#execute` now retries connection resets/refusals, timeouts, and SSL errors up to 3 times with linear backoff before giving up.
- `google_drive:export` now rescues per-project instead of letting one project's unrecoverable failure abort every project after it. Failed projects are logged by name/id at the end; re-running the task naturally retries just those, since already-exported projects are skipped.

## Test plan
- [x] `ruby -c` on both changed files
- [ ] CI passes
- [ ] Merge and deploy
- [ ] Re-run `google_drive:export` in production to completion